### PR TITLE
修复圆角显示不正确问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /build
 /captures
 .externalNativeBuild
+.idea

--- a/badgeviewlib/src/main/java/q/rorbin/badgeview/QBadgeView.java
+++ b/badgeviewlib/src/main/java/q/rorbin/badgeview/QBadgeView.java
@@ -344,9 +344,8 @@ public class QBadgeView extends View implements Badge {
             mBadgeBackgroundRect.top = center.y - (mBadgeTextRect.height() / 2f + mBadgePadding * 0.5f);
             mBadgeBackgroundRect.right = center.x + (mBadgeTextRect.width() / 2f + mBadgePadding);
             mBadgeBackgroundRect.bottom = center.y + (mBadgeTextRect.height() / 2f + mBadgePadding * 0.5f);
-            canvas.drawRoundRect(mBadgeBackgroundRect,
-                    DisplayUtil.dp2px(getContext(), 100), DisplayUtil.dp2px(getContext(), 100),
-                    mBadgeBackgroundPaint);
+            radius = mBadgeBackgroundRect.height() / 2f;
+            canvas.drawRoundRect(mBadgeBackgroundRect, radius, radius, mBadgeBackgroundPaint);
         }
         if (!mBadgeText.isEmpty()) {
             canvas.drawText(mBadgeText, center.x,


### PR DESCRIPTION
圆角半径设置了一个很大的值（100），在部分机型显示为半圆，但在部分机型是按设置的值显示，两边会出现尖角，改为设置正确的圆角半径值。