### PR TITLE
解决在RelativeLayout等依赖view id的布局中findViewById的错误

### DIFF
--- a/badgeviewlib/src/main/java/q/rorbin/badgeview/QBadgeView.java
+++ b/badgeviewlib/src/main/java/q/rorbin/badgeview/QBadgeView.java
@@ -155,7 +155,7 @@ public class QBadgeView extends View implements Badge {
                 ViewGroup.LayoutParams targetParams = targetView.getLayoutParams();
                 targetContainer.removeView(targetView);
                 final BadgeContainer badgeContainer = new BadgeContainer(getContext());
-                if(targetContainer instanceof RelativeLayout){
+                if (targetContainer instanceof RelativeLayout) {
                     badgeContainer.setId(targetView.getId());
                 }
                 targetContainer.addView(badgeContainer, index, targetParams);
@@ -832,7 +832,7 @@ public class QBadgeView extends View implements Badge {
 
         @Override
         protected void dispatchRestoreInstanceState(SparseArray<Parcelable> container) {
-            if(!(getParent() instanceof RelativeLayout)){
+            if (!(getParent() instanceof RelativeLayout)) {
                 super.dispatchRestoreInstanceState(container);
             }
         }
@@ -870,6 +870,22 @@ public class QBadgeView extends View implements Badge {
                 }
                 setMeasuredDimension(targetView.getMeasuredWidth(), targetView.getMeasuredHeight());
             }
+        }
+
+        protected View findViewTraversal(int id) {
+
+            final int len = getChildCount();
+
+            for (int i = 0; i < len; i++) {
+                View v = getChildAt(i);
+                v = v.findViewById(id);
+
+                if (v != null) {
+                    return v;
+                }
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
原理：从findViewById的源码中可以看出，最终调用的是findViewTraversal，因此重写BadgeContainer的findViewTraversal的查找逻辑，即可完美解决依赖id的View布局导致的findViewById错误！